### PR TITLE
Support for directly building packages w/ chroots

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/chroot/builders/ChrootPackageBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/chroot/builders/ChrootPackageBuilder.java
@@ -29,6 +29,7 @@ import hudson.Extension;
 import hudson.FilePath;
 import hudson.FilePath.FileCallable;
 import hudson.Launcher;
+import hudson.matrix.MatrixProject;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.AutoCompletionCandidates;
@@ -58,6 +59,7 @@ import org.kohsuke.stapler.QueryParameter;
 public class ChrootPackageBuilder extends Builder implements Serializable {
 
     private String chrootName;
+    private String archAllLabel;
     private boolean ignoreExit;
     private List<String> packagesFromFile;
     private boolean clear;
@@ -74,9 +76,10 @@ public class ChrootPackageBuilder extends Builder implements Serializable {
     }
 
     @DataBoundConstructor
-    public ChrootPackageBuilder(String chrootName, boolean ignoreExit, boolean clear,
+    public ChrootPackageBuilder(String chrootName, String archAllLabel, boolean ignoreExit, boolean clear,
             String sourcePackage, boolean noUpdate, boolean forceInstall) throws IOException {
         this.chrootName = chrootName;
+        this.archAllLabel = archAllLabel;
         this.ignoreExit = ignoreExit;
         this.clear = clear;
         this.sourcePackage = sourcePackage;
@@ -86,6 +89,10 @@ public class ChrootPackageBuilder extends Builder implements Serializable {
 
     public String getChrootName() {
         return chrootName;
+    }
+    
+    public String getArchAllLabel() {
+        return archAllLabel;
     }
 
     public String getSourcePackage() {
@@ -155,7 +162,7 @@ public class ChrootPackageBuilder extends Builder implements Serializable {
             }
         }
         ChrootUtil.saveDigest(workerTarBall);
-        return ignoreExit || installation.getChrootWorker().perform(build, launcher, listener, workerTarBall, this.sourcePackage);
+        return ignoreExit || installation.getChrootWorker().perform(build, launcher, listener, workerTarBall, this.archAllLabel, this.sourcePackage);
     }
 
     @Extension

--- a/src/main/java/org/jenkinsci/plugins/chroot/builders/ChrootPackageBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/chroot/builders/ChrootPackageBuilder.java
@@ -1,0 +1,206 @@
+/*
+ *  Copyright 2013, Roman Mohr <roman@fenkhuber.at>
+ *  Copyright 2016, Xamarin, Inc
+ *
+ *  This file is part of Chroot-plugin.
+ *
+ *  Chroot-plugin is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Chroot-plugin is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Chroot-plugin.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * To change this template, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.jenkinsci.plugins.chroot.builders;
+
+import hudson.EnvVars;
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.FilePath.FileCallable;
+import hudson.Launcher;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.AutoCompletionCandidates;
+import hudson.model.BuildListener;
+import hudson.model.FreeStyleProject;
+import hudson.remoting.VirtualChannel;
+import hudson.tasks.BuildStepDescriptor;
+import hudson.tasks.Builder;
+import hudson.util.FormValidation;
+import java.io.File;
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.LinkedList;
+import java.util.List;
+import javax.servlet.ServletException;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.plugins.chroot.tools.ChrootToolset;
+import org.jenkinsci.plugins.chroot.util.ChrootUtil;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+
+/**
+ *
+ * @author roman
+ */
+public class ChrootPackageBuilder extends Builder implements Serializable {
+
+    private String chrootName;
+    private boolean ignoreExit;
+    private List<String> packagesFromFile;
+    private boolean clear;
+    private String sourcePackage;
+    private boolean noUpdate;
+    private boolean forceInstall;
+
+    public boolean isForceInstall() {
+        return forceInstall;
+    }
+
+    public boolean isNoUpdate() {
+        return noUpdate;
+    }
+
+    @DataBoundConstructor
+    public ChrootPackageBuilder(String chrootName, boolean ignoreExit, boolean clear,
+            String sourcePackage, boolean noUpdate, boolean forceInstall) throws IOException {
+        this.chrootName = chrootName;
+        this.ignoreExit = ignoreExit;
+        this.clear = clear;
+        this.sourcePackage = sourcePackage;
+        this.noUpdate = noUpdate;
+        this.forceInstall = forceInstall;
+    }
+
+    public String getChrootName() {
+        return chrootName;
+    }
+
+    public String getSourcePackage() {
+        return sourcePackage;
+    }
+
+    public boolean isIgnoreExit() {
+        return ignoreExit;
+    }
+
+    public boolean isClear() {
+        return clear;
+    }
+
+    private static final class LocalCopyTo implements FileCallable<Void> {
+
+        private final String target;
+
+        public LocalCopyTo(String target) {
+            this.target = target;
+        }
+
+        public Void invoke(File source, VirtualChannel channel) throws IOException, InterruptedException {
+            FilePath _source = new FilePath(source);
+            FilePath _target = new FilePath(new File(target));
+            _source.copyTo(_target);
+            return null;
+        }
+    }
+
+    @Override
+    public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+        EnvVars env = build.getEnvironment(listener);
+        ChrootToolset installation = ChrootToolset.getInstallationByName(env.expand(this.chrootName));
+        installation = installation.forNode(build.getBuiltOn(), listener);
+        installation = installation.forEnvironment(env);
+        if (installation.getHome() == null) {
+            listener.fatalError("Installation of chroot environment failed");
+            listener.fatalError("Please check if pbuilder is installed on the selected node and that"
+                    + " the user, Jenkins uses, cann run pbuilder with sudo.");
+            return false;
+        }
+        FilePath tarBall = new FilePath(build.getBuiltOn().getChannel(), installation.getHome());
+
+        FilePath workerTarBall = build.getWorkspace().child(env.expand(this.chrootName)).child(tarBall.getName());
+        workerTarBall.getParent().mkdirs();
+
+        // force environment recreation when clear is selected
+        if (isClear()) {
+            boolean ret = installation.getChrootWorker().cleanUp(build, launcher, listener, workerTarBall);
+            if (ret == false) {
+                listener.fatalError("Chroot environment cleanup failed");
+                return ret || ignoreExit;
+            }
+        }
+
+        if (!workerTarBall.exists() || !ChrootUtil.isFileIntact(workerTarBall) || tarBall.lastModified() > workerTarBall.lastModified()) {
+            tarBall.act(new LocalCopyTo(workerTarBall.getRemote()));
+            ChrootUtil.getDigestFile(tarBall).act(new LocalCopyTo(ChrootUtil.getDigestFile(workerTarBall).getRemote()));
+        }
+
+        if (!this.isNoUpdate()) {
+            boolean ret = installation.getChrootWorker().updateRepositories(build, launcher, listener, workerTarBall);
+            if (ret == false) {
+                listener.fatalError("Updating repository indices in chroot environment failed.");
+                return ret || ignoreExit;
+            }
+        }
+        ChrootUtil.saveDigest(workerTarBall);
+        return ignoreExit || installation.getChrootWorker().perform(build, launcher, listener, workerTarBall, this.sourcePackage);
+    }
+
+    @Extension
+    public static class DescriptorImpl extends BuildStepDescriptor<Builder> {
+
+        public AutoCompletionCandidates doAutoCompleteChrootName(@QueryParameter String value) {
+            AutoCompletionCandidates c = new AutoCompletionCandidates();
+            for (ChrootToolset set : ChrootToolset.list()) {
+                if(set.getName().startsWith(value))
+                    c.add(set.getName());
+            }
+            return c;
+        }
+
+        @Override
+        public boolean isApplicable(Class<? extends AbstractProject> jobType) {
+            return FreeStyleProject.class.isAssignableFrom(jobType);
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Chroot Package Builder";
+        }
+
+        public FormValidation doCheckPackagesFile(@QueryParameter String value)
+                throws IOException, ServletException, InterruptedException {
+            List<String> validationList = new LinkedList<String>();
+            Boolean warn = false;
+            Boolean error = false;
+            for (String file : ChrootUtil.splitFiles(value)) {
+                FilePath x = new FilePath(new File(file));
+                if (!x.exists()) {
+                    warn = true;
+                    validationList.add(String.format("File %s does not yet exist.", file));
+                } else if (x.isDirectory()) {
+                    error = true;
+                    validationList.add(String.format("%s is a directory. Enter a file.", file));
+                }
+            }
+            if (error == true) {
+                return FormValidation.error(StringUtils.join(validationList.listIterator(), "\n"));
+            } else if (warn == true) {
+                return FormValidation.warning(StringUtils.join(validationList.listIterator(), "\n"));
+            }
+            return FormValidation.ok();
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/chroot/builders/ChrootPackageBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/chroot/builders/ChrootPackageBuilder.java
@@ -172,7 +172,7 @@ public class ChrootPackageBuilder extends Builder implements Serializable {
 
         @Override
         public boolean isApplicable(Class<? extends AbstractProject> jobType) {
-            return FreeStyleProject.class.isAssignableFrom(jobType);
+            return true;
         }
 
         @Override

--- a/src/main/java/org/jenkinsci/plugins/chroot/extensions/ChrootWorker.java
+++ b/src/main/java/org/jenkinsci/plugins/chroot/extensions/ChrootWorker.java
@@ -60,6 +60,8 @@ public abstract class ChrootWorker implements ExtensionPoint {
     public abstract FilePath setUp(ToolInstallation tool, Node node, TaskListener log) throws IOException, InterruptedException;
 
     public abstract boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener, FilePath tarBall, String commands, boolean runAsRoot) throws IOException, InterruptedException;
+    
+    public abstract boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener, FilePath tarBall, String sourcePackage) throws IOException, InterruptedException;
 
     public abstract boolean installPackages(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener, FilePath tarBall, List<String> packages, boolean forceInstall) throws IOException, InterruptedException;
 

--- a/src/main/java/org/jenkinsci/plugins/chroot/extensions/ChrootWorker.java
+++ b/src/main/java/org/jenkinsci/plugins/chroot/extensions/ChrootWorker.java
@@ -61,7 +61,7 @@ public abstract class ChrootWorker implements ExtensionPoint {
 
     public abstract boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener, FilePath tarBall, String commands, boolean runAsRoot) throws IOException, InterruptedException;
     
-    public abstract boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener, FilePath tarBall, String sourcePackage) throws IOException, InterruptedException;
+    public abstract boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener, FilePath tarBall, String archAllLabel, String sourcePackage) throws IOException, InterruptedException;
 
     public abstract boolean installPackages(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener, FilePath tarBall, List<String> packages, boolean forceInstall) throws IOException, InterruptedException;
 

--- a/src/main/java/org/jenkinsci/plugins/chroot/extensions/MockWorker.java
+++ b/src/main/java/org/jenkinsci/plugins/chroot/extensions/MockWorker.java
@@ -128,7 +128,7 @@ public final class MockWorker extends ChrootWorker {
     }
     
     @Override
-    public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener, FilePath tarBall, String sourcepackage) throws IOException, InterruptedException {
+    public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener, FilePath tarBall, String archAllLabel, String sourcepackage) throws IOException, InterruptedException {
 
         EnvVars environment = build.getEnvironment(listener);
         FilePath[] sourcePackageFiles = build.getWorkspace().list(Util.replaceMacro(sourcepackage, environment));

--- a/src/main/java/org/jenkinsci/plugins/chroot/extensions/MockWorker.java
+++ b/src/main/java/org/jenkinsci/plugins/chroot/extensions/MockWorker.java
@@ -24,6 +24,7 @@
 package org.jenkinsci.plugins.chroot.extensions;
 
 import com.google.common.collect.ImmutableList;
+import hudson.EnvVars;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
@@ -122,6 +123,19 @@ public final class MockWorker extends ChrootWorker {
 
         int exitCode = launcher.launch().cmds(b).stdout(listener).stderr(listener.getLogger()).join();
         script.delete();
+        return exitCode == 0;
+    }
+    
+    @Override
+    public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener, FilePath tarBall, String sourcepackage) throws IOException, InterruptedException {
+
+        EnvVars environment = build.getEnvironment(listener);
+        sourcepackage = environment.expand(sourcepackage);
+        
+        ArgumentListBuilder b = new ArgumentListBuilder().add(getTool())
+                .add("--rebuild").add(sourcepackage);
+
+        int exitCode = launcher.launch().cmds(b).stdout(listener).stderr(listener.getLogger()).join();
         return exitCode == 0;
     }
 

--- a/src/main/java/org/jenkinsci/plugins/chroot/extensions/PBuilderWorker.java
+++ b/src/main/java/org/jenkinsci/plugins/chroot/extensions/PBuilderWorker.java
@@ -193,7 +193,7 @@ public final class PBuilderWorker extends ChrootWorker {
     }
     
     @Override
-    public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener, FilePath tarBall, String sourcePackage) throws IOException, InterruptedException {
+    public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener, FilePath tarBall, String archAllLabel, String sourcePackage) throws IOException, InterruptedException {
         FilePath buildplace = new FilePath(launcher.getChannel(), java.nio.file.Paths.get(build.getWorkspace().getRemote(), "buildroot").toString());
         FilePath results = new FilePath(launcher.getChannel(), java.nio.file.Paths.get(build.getWorkspace().getRemote(), "results").toString());
         if (!buildplace.exists()) {

--- a/src/main/java/org/jenkinsci/plugins/chroot/extensions/PBuilderWorker.java
+++ b/src/main/java/org/jenkinsci/plugins/chroot/extensions/PBuilderWorker.java
@@ -196,6 +196,7 @@ public final class PBuilderWorker extends ChrootWorker {
     public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener, FilePath tarBall, String archAllLabel, String sourcePackage) throws IOException, InterruptedException {
         FilePath buildplace = new FilePath(launcher.getChannel(), java.nio.file.Paths.get(build.getWorkspace().getRemote(), "buildroot").toString());
         FilePath results = new FilePath(launcher.getChannel(), java.nio.file.Paths.get(build.getWorkspace().getRemote(), "results").toString());
+        String archFlag = "-b";
         if (!buildplace.exists()) {
             buildplace.mkdirs();
             if (!buildplace.exists()) {
@@ -217,10 +218,16 @@ public final class PBuilderWorker extends ChrootWorker {
             listener.fatalError("Invalid number of source packages specified (must be 1)");
             return false;
         }
+        if(archAllLabel != null)
+            if(build.getBuildVariables().containsValue(archAllLabel))
+                archFlag = "-b";
+            else
+                archFlag = "-B";
         ArgumentListBuilder b = new ArgumentListBuilder().add("sudo").add(getTool()).add("--build")
                 .add("--buildplace").add(buildplace.toString())
                 .add("--buildresult").add(results.toString())
                 .add("--basetgz").add(tarBall.getRemote())
+                .add("--debbuildopts").add("\"" + archFlag + "\"")
                 .add("--").add(sourcePackageFiles[0]);
         int exitCode = launcher.launch().cmds(b).envs(environment).stdout(listener).stderr(listener.getLogger()).join();
         return exitCode == 0;

--- a/src/main/java/org/jenkinsci/plugins/chroot/extensions/PBuilderWorker.java
+++ b/src/main/java/org/jenkinsci/plugins/chroot/extensions/PBuilderWorker.java
@@ -194,10 +194,22 @@ public final class PBuilderWorker extends ChrootWorker {
     
     @Override
     public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener, FilePath tarBall, String sourcePackage) throws IOException, InterruptedException {
-        File buildplace = java.nio.file.Paths.get(build.getWorkspace().getRemote(),"buildroot").toFile();
-        File results = java.nio.file.Paths.get(build.getWorkspace().getRemote(),"results").toFile();
-        if(!buildplace.isDirectory() && !results.isDirectory() && !(buildplace.mkdir() && results.mkdir()))
-            return false;
+        FilePath buildplace = new FilePath(launcher.getChannel(), java.nio.file.Paths.get(build.getWorkspace().getRemote(), "buildroot").toString());
+        FilePath results = new FilePath(launcher.getChannel(), java.nio.file.Paths.get(build.getWorkspace().getRemote(), "results").toString());
+        if (!buildplace.exists()) {
+            buildplace.mkdirs();
+            if (!buildplace.exists()) {
+                listener.fatalError("failed to create buildplace dir " + buildplace.getName());
+                return false;
+            }
+        }
+        if (!results.exists()) {
+            results.mkdirs();
+            if (!results.exists()) {
+                listener.fatalError("failed to create results dir " + results.getName());
+                return false;
+            }
+        }
         
         EnvVars environment = build.getEnvironment(listener);
         FilePath[] sourcePackageFiles = build.getWorkspace().list(Util.replaceMacro(sourcePackage, environment));

--- a/src/main/java/org/jenkinsci/plugins/chroot/extensions/PBuilderWorker.java
+++ b/src/main/java/org/jenkinsci/plugins/chroot/extensions/PBuilderWorker.java
@@ -202,7 +202,7 @@ public final class PBuilderWorker extends ChrootWorker {
         EnvVars environment = build.getEnvironment(listener);
         FilePath[] sourcePackageFiles = build.getWorkspace().list(Util.replaceMacro(sourcePackage, environment));
         if (sourcePackageFiles.length != 1) {
-            //log.fatalError("Invalid number of source packages specified (must be 1)");
+            listener.fatalError("Invalid number of source packages specified (must be 1)");
             return false;
         }
         ArgumentListBuilder b = new ArgumentListBuilder().add("sudo").add(getTool()).add("--build")

--- a/src/main/resources/org/jenkinsci/plugins/chroot/builders/ChrootPackageBuilder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/chroot/builders/ChrootPackageBuilder/config.jelly
@@ -30,6 +30,11 @@
 </f:entry>
 
 <f:advanced>
+    <j:if test="${it.getClass().canonicalName == 'hudson.matrix.MatrixProject'}">
+        <f:entry field="archAllLabel" title="Primary matrix configuration">
+            <f:textbox/>
+        </f:entry>
+    </j:if>
 <f:entry field="ignoreExit" title="Ignore exit code">
 <f:checkbox />
 </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/chroot/builders/ChrootPackageBuilder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/chroot/builders/ChrootPackageBuilder/config.jelly
@@ -1,0 +1,45 @@
+<!--
+ Copyright 2013, Roman Mohr <roman@fenkhuber.at>
+ Copyright 2016, Xamarin, Inc
+
+ This file is part of Chroot-plugin.
+
+ Chroot-plugin is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Chroot-plugin is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Chroot-plugin.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<f:entry field="chrootName" title="Chroot Environment">
+   <f:textbox />
+</f:entry>
+<f:entry field="clear" title="Clear">
+<f:checkbox />
+</f:entry>
+<f:entry field="sourcePackage" title="Source package">
+<f:textbox/>
+</f:entry>
+
+<f:advanced>
+<f:entry field="ignoreExit" title="Ignore exit code">
+<f:checkbox />
+</f:entry>
+<f:entry field="noUpdate" title="Do not update repository indices">
+<f:checkbox />
+</f:entry>
+<f:entry field="forceInstall" title="Force installation of packages">
+<f:checkbox />
+</f:entry>
+</f:advanced>
+
+
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/chroot/builders/ChrootPackageBuilder/help-archAllLabel.html
+++ b/src/main/resources/org/jenkinsci/plugins/chroot/builders/ChrootPackageBuilder/help-archAllLabel.html
@@ -1,0 +1,21 @@
+<!--
+ Copyright 2013, Roman Mohr <roman@fenkhuber.at>
+ Copyright 2016, Xamarin, Inc
+
+ This file is part of Chroot-plugin.
+
+ Chroot-plugin is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Chroot-plugin is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Chroot-plugin.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+dpkg-buildpackage by default builds all binary packages from a source package which match the current architecture, or are architecture "All". A label here will result in architecture:All packages only being built on that label.

--- a/src/main/resources/org/jenkinsci/plugins/chroot/builders/ChrootPackageBuilder/help-clear.html
+++ b/src/main/resources/org/jenkinsci/plugins/chroot/builders/ChrootPackageBuilder/help-clear.html
@@ -1,0 +1,21 @@
+<!--
+ Copyright 2013, Roman Mohr <roman@fenkhuber.at>
+
+ This file is part of Chroot-plugin.
+
+ Chroot-plugin is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Chroot-plugin is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Chroot-plugin.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+Uses a fresh copied chroot tarball without packages installed from previous runs.
+The build will take longer but the build results will be more meaningful.

--- a/src/main/resources/org/jenkinsci/plugins/chroot/builders/ChrootPackageBuilder/help-forceInstall.html
+++ b/src/main/resources/org/jenkinsci/plugins/chroot/builders/ChrootPackageBuilder/help-forceInstall.html
@@ -1,0 +1,21 @@
+<!--
+ Copyright 2013, Roman Mohr <roman@fenkhuber.at>
+
+ This file is part of Chroot-plugin.
+
+ Chroot-plugin is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Chroot-plugin is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Chroot-plugin.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+This option allows to force the installation of the specified packages. The underlying container will do whatever it can do to fulfill this request.
+This allows actions like downgrading, installing untrusted packages, etc.

--- a/src/main/resources/org/jenkinsci/plugins/chroot/builders/ChrootPackageBuilder/help-ignoreExit.html
+++ b/src/main/resources/org/jenkinsci/plugins/chroot/builders/ChrootPackageBuilder/help-ignoreExit.html
@@ -1,0 +1,20 @@
+<!--
+ Copyright 2013, Roman Mohr <roman@fenkhuber.at>
+
+ This file is part of Chroot-plugin.
+
+ Chroot-plugin is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Chroot-plugin is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Chroot-plugin.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+The build will always succeed.

--- a/src/main/resources/org/jenkinsci/plugins/chroot/builders/ChrootPackageBuilder/help-noUpdate.html
+++ b/src/main/resources/org/jenkinsci/plugins/chroot/builders/ChrootPackageBuilder/help-noUpdate.html
@@ -1,0 +1,23 @@
+<!--
+ Copyright 2013, Roman Mohr <roman@fenkhuber.at>
+
+ This file is part of Chroot-plugin.
+
+ Chroot-plugin is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Chroot-plugin is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Chroot-plugin.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+When this option is enabled, the repository indices are only updated if extra packages are going to be installed.
+When disabling repository updates, self contained builds, which do not have to install packages, will run faster.
+
+Because packages can also be installed from commands within the buildstep, by default, the package indices are always updated.

--- a/src/main/resources/org/jenkinsci/plugins/chroot/builders/ChrootPackageBuilder/help-sourcePackage.html
+++ b/src/main/resources/org/jenkinsci/plugins/chroot/builders/ChrootPackageBuilder/help-sourcePackage.html
@@ -1,0 +1,21 @@
+<!--
+ Copyright 2013, Roman Mohr <roman@fenkhuber.at>
+ Copyright 2016, Xamarin, Inc
+
+ This file is part of Chroot-plugin.
+
+ Chroot-plugin is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Chroot-plugin is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Chroot-plugin.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+Enter the fully qualified path to the source package you wish to build (a .dsc or .src.rpm file) - use WORKSPACE variable for paths relative to workspace


### PR DESCRIPTION
Since both pbuilder & mock are intended for easy package building, it's a little odd that this plugin doesn't allow builder chroots to be used to build packages.

This PR adds a new build step, which recycles the same chroots to build source packages via either "mock --rebuild foo.src.rpm" or "pbuilder build foo.dsc"

RPM version not exhaustively tested, but works as proof-of-concept