### PR TITLE
Assume IsApplicable is always true, don't restrict to FreestyleProject

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/chroot/builders/ChrootBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/chroot/builders/ChrootBuilder.java
@@ -209,7 +209,7 @@ public class ChrootBuilder extends Builder implements Serializable {
 
         @Override
         public boolean isApplicable(Class<? extends AbstractProject> jobType) {
-            return FreeStyleProject.class.isAssignableFrom(jobType);
+            return true;
         }
 
         @Override


### PR DESCRIPTION
This is a follow-up to https://github.com/jenkinsci/chroot-plugin/pull/6

Without it, Chroot steps are hidden from the list of build steps on Matrix jobs.

With it, a simple idiom is to assign labels to nodes, and create chroots with matching names - so a matrix job could have a label axis of `alpha beta`, and a chroot step configured to execute on `${label}-foo`, which will successfully run the job twice, once in the chroot named `alpha-foo` and once in `beta-foo`