### PR TITLE
Mock support

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/chroot/extensions/MockWorker.java
+++ b/src/main/java/org/jenkinsci/plugins/chroot/extensions/MockWorker.java
@@ -17,7 +17,7 @@
  *  along with Chroot-plugin.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/*
+ /*
  * To change this template, choose Tools | Templates
  * and open the template in the editor.
  */
@@ -53,7 +53,7 @@ import org.jenkinsci.plugins.chroot.util.ChrootUtil;
 public final class MockWorker extends ChrootWorker {
 
     private static final Logger logger = Logger.getLogger("jenkins.plugins.chroot.extensions.MockWorker");
-    
+
     @Override
     public FilePath setUp(ToolInstallation tool, Node node, TaskListener log) throws IOException, InterruptedException {
         FilePath rootDir = node.getRootPath();
@@ -155,7 +155,7 @@ public final class MockWorker extends ChrootWorker {
         int ret = launcher.launch().cmds(cmd).stdout(listener).stderr(listener.getLogger()).join();
         return exitCode == 0;
     }
-    
+
     @Override
     public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener, FilePath tarBall, String archAllLabel, String sourcepackage) throws IOException, InterruptedException {
 
@@ -165,7 +165,7 @@ public final class MockWorker extends ChrootWorker {
             //log.fatalError("Invalid number of source packages specified (must be 1)");
             return false;
         }
-        
+
         ArgumentListBuilder b = new ArgumentListBuilder().add(getTool())
                 .add("--rebuild").add(sourcePackageFiles[0]);
 
@@ -233,7 +233,8 @@ public final class MockWorker extends ChrootWorker {
             logger.log(Level.SEVERE, null, ex);
         }
         logger.log(Level.SEVERE, stderr.toString());
-        return false;    }
+        return false;
+    }
 
     @Override
     public List<String> getFallbackPackages() {

--- a/src/main/java/org/jenkinsci/plugins/chroot/extensions/MockWorker.java
+++ b/src/main/java/org/jenkinsci/plugins/chroot/extensions/MockWorker.java
@@ -66,7 +66,7 @@ public final class MockWorker extends ChrootWorker {
         FilePath chrootDir = node.getRootPath().createTempDir(tool.getName(), "");
         FilePath cacheDir = chrootDir.child("cache");
         FilePath buildDir = chrootDir.child("root");
-        FilePath resultDir = chrootDir.child("result");
+        FilePath resultDir = rootDir.child("result");
 
         if (!tarBall.exists()) {
             // copy /etc/mock/default.cfg to this location
@@ -123,7 +123,7 @@ public final class MockWorker extends ChrootWorker {
         FilePath rootDir = build.getWorkspace();
         Node node = build.getBuiltOn();
         FilePath chrootDir = rootDir.createTempDir("chroot", "");
-        FilePath resultDir = chrootDir.child("result");
+        FilePath resultDir = rootDir.child("result");
         FilePath buildDir = chrootDir.child("root");
         FilePath cacheDir = chrootDir.child("cache");
         FilePath default_cfg = new FilePath(chrootDir, toolName + ".cfg");
@@ -196,7 +196,8 @@ public final class MockWorker extends ChrootWorker {
     public boolean updateRepositories(AbstractBuild<?, ?> build, Launcher launcher, BuildListener log, FilePath tarBall) throws IOException, InterruptedException {
         try {
             String toolName = getToolInstanceName(launcher, log, tarBall);
-            FilePath chrootDir = build.getBuiltOn().getRootPath().createTempDir(toolName, "");
+            FilePath rootDir = build.getBuiltOn().getRootPath();
+            FilePath chrootDir = rootDir.createTempDir(toolName, "");
             FilePath cacheDir = chrootDir.child("cache");
             FilePath buildDir = chrootDir.child("build");
             FilePath resultDir = chrootDir.child("result");

--- a/src/main/java/org/jenkinsci/plugins/chroot/extensions/MockWorker.java
+++ b/src/main/java/org/jenkinsci/plugins/chroot/extensions/MockWorker.java
@@ -229,6 +229,7 @@ public final class MockWorker extends ChrootWorker {
             FilePath cacheDir = chrootDir.child("cache");
             FilePath buildDir = chrootDir.child("build");
             FilePath resultDir = chrootDir.child("result");
+            resultDir.mkdirs();
             unpackChroot(build.getBuiltOn(), log, tarBall, chrootDir);
             ArgumentListBuilder cmd = new ArgumentListBuilder();
             FilePath default_cfg = new FilePath(chrootDir, toolName + ".cfg");

--- a/src/main/java/org/jenkinsci/plugins/chroot/extensions/MockWorker.java
+++ b/src/main/java/org/jenkinsci/plugins/chroot/extensions/MockWorker.java
@@ -211,6 +211,9 @@ public final class MockWorker extends ChrootWorker {
                     .add("--update");
             int ret = launcher.launch().cmds(cmd).stdout(log).stderr(log.getLogger()).join();
             packChroot(build.getBuiltOn(), log, tarBall, chrootDir);
+            cmd = new ArgumentListBuilder();
+            cmd.add("sudo").add("rm").add("-fr").add(chrootDir);
+            ret = launcher.launch().cmds(cmd).stdout(log).stderr(log.getLogger()).join();
             return true;
         } catch (Exception e) {
             return false;

--- a/src/main/java/org/jenkinsci/plugins/chroot/extensions/MockWorker.java
+++ b/src/main/java/org/jenkinsci/plugins/chroot/extensions/MockWorker.java
@@ -36,12 +36,14 @@ import hudson.model.TaskListener;
 import hudson.tools.ToolInstallation;
 import hudson.util.ArgumentListBuilder;
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.jenkinsci.plugins.chroot.tools.ChrootToolsetProperty;
 import org.jenkinsci.plugins.chroot.tools.Repository;
+import org.jenkinsci.plugins.chroot.util.ChrootUtil;
 
 /**
  *

--- a/src/main/java/org/jenkinsci/plugins/chroot/extensions/MockWorker.java
+++ b/src/main/java/org/jenkinsci/plugins/chroot/extensions/MockWorker.java
@@ -65,7 +65,7 @@ public final class MockWorker extends ChrootWorker {
         tarBall = rootDir.child(tool.getName() + ".tgz");
         FilePath chrootDir = node.getRootPath().createTempDir(tool.getName(), "");
         FilePath cacheDir = chrootDir.child("cache");
-        FilePath buildDir = chrootDir.child("build");
+        FilePath buildDir = chrootDir.child("root");
         FilePath resultDir = chrootDir.child("result");
 
         if (!tarBall.exists()) {
@@ -94,6 +94,10 @@ public final class MockWorker extends ChrootWorker {
                     .add("--init");
             Launcher launcher = node.createLauncher(log);
             int ret = launcher.launch().cmds(cmd).stdout(log).stderr(log.getLogger()).join();
+            packChroot(node, log, tarBall, chrootDir);
+            cmd = new ArgumentListBuilder();
+            cmd.add("sudo").add("rm").add("-fr").add(chrootDir);
+            ret = launcher.launch().cmds(cmd).stdout(log).stderr(log.getLogger()).join();
         }
         return tarBall;
     }

--- a/src/main/java/org/jenkinsci/plugins/chroot/extensions/MockWorker.java
+++ b/src/main/java/org/jenkinsci/plugins/chroot/extensions/MockWorker.java
@@ -63,7 +63,7 @@ public final class MockWorker extends ChrootWorker {
 
         if (!tarBall.exists()) {
             // copy /etc/mock/default.cfg to this location
-            FilePath system_default_cfg = node.createPath("/etc/mock/default.cfg");
+            FilePath system_default_cfg = node.createPath("/etc/mock/" + tool.getName() + ".cfg");
             FilePath system_logging_cfg = node.createPath("/etc/mock/logging.ini");
             FilePath default_cfg = new FilePath(chrootDir, tool.getName() + ".cfg");
             FilePath logging_cfg = new FilePath(chrootDir, "logging.ini");


### PR DESCRIPTION
This fixes up Mock well enough for our use in production. Unfortunately, Mock doesn't have a "nice" mode for console output - either it's silent, or heavy debugging. I opted for heavy debugging, otherwise logcat is useless.

Example: https://jenkins.mono-project.com/job/nightly-stablerpm-stablepkg/96/label=epel-7-x86_64/consoleFull
