### PR TITLE
Add support for bind mounting directories inside the chroot.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/chroot/builders/ChrootBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/chroot/builders/ChrootBuilder.java
@@ -61,6 +61,7 @@ public class ChrootBuilder extends Builder implements Serializable {
     private boolean ignoreExit;
     private List<String> additionalPackages;
     private String packagesFile;
+    private String bindMounts;
     private boolean clear;
     private String command;
     private boolean loginAsRoot;
@@ -77,12 +78,13 @@ public class ChrootBuilder extends Builder implements Serializable {
 
     @DataBoundConstructor
     public ChrootBuilder(String chrootName, boolean ignoreExit,
-            String additionalPackages, String packagesFile, boolean clear,
+            String additionalPackages, String packagesFile, String bindMounts, boolean clear,
             String command, boolean loginAsRoot, boolean noUpdate, boolean forceInstall) throws IOException {
         this.loginAsRoot = loginAsRoot;
         this.chrootName = chrootName;
         this.ignoreExit = ignoreExit;
         this.additionalPackages = ChrootUtil.splitPackages(additionalPackages);
+        this.bindMounts = bindMounts;
         this.packagesFile = packagesFile;
         this.clear = clear;
         this.command = command;
@@ -112,6 +114,10 @@ public class ChrootBuilder extends Builder implements Serializable {
 
     public String getPackagesFile() {
         return packagesFile;
+    }
+    
+    public String getBindMounts() {
+        return bindMounts;
     }
 
     public boolean isClear() {
@@ -192,7 +198,7 @@ public class ChrootBuilder extends Builder implements Serializable {
             }
         }
         ChrootUtil.saveDigest(workerTarBall);
-        return ignoreExit || installation.getChrootWorker().perform(build, launcher, listener, workerTarBall, this.command, isLoginAsRoot());
+        return ignoreExit || installation.getChrootWorker().perform(build, launcher, listener, workerTarBall, this.command, this.bindMounts, isLoginAsRoot());
     }
 
     @Extension

--- a/src/main/java/org/jenkinsci/plugins/chroot/extensions/ChrootWorker.java
+++ b/src/main/java/org/jenkinsci/plugins/chroot/extensions/ChrootWorker.java
@@ -59,7 +59,7 @@ public abstract class ChrootWorker implements ExtensionPoint {
 
     public abstract FilePath setUp(ToolInstallation tool, Node node, TaskListener log) throws IOException, InterruptedException;
 
-    public abstract boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener, FilePath tarBall, String commands, boolean runAsRoot) throws IOException, InterruptedException;
+    public abstract boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener, FilePath tarBall, String commands, String bindMounts, boolean runAsRoot) throws IOException, InterruptedException;
     
     public abstract boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener, FilePath tarBall, String archAllLabel, String sourcePackage) throws IOException, InterruptedException;
 

--- a/src/main/java/org/jenkinsci/plugins/chroot/extensions/MockWorker.java
+++ b/src/main/java/org/jenkinsci/plugins/chroot/extensions/MockWorker.java
@@ -41,6 +41,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.chroot.tools.ChrootToolsetProperty;
 import org.jenkinsci.plugins.chroot.tools.Repository;
 import org.jenkinsci.plugins.chroot.util.ChrootUtil;
@@ -113,7 +114,12 @@ public final class MockWorker extends ChrootWorker {
     }
 
     @Override
-    public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener, FilePath tarBall, String commands, boolean runAsRoot) throws IOException, InterruptedException {
+    public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener, FilePath tarBall, String commands, String bindMounts, boolean runAsRoot) throws IOException, InterruptedException {
+        if (!StringUtils.isEmpty(bindMounts)) {
+            logger.log(Level.SEVERE,"Bind mounts not supported by Mock");
+            listener.getLogger().append("***Bind mounts not supported by Mock***\n");
+            return false;
+        }
         String toolName = getToolInstanceName(launcher, listener, tarBall);
         String userName = super.getUserName(launcher);
         int id = super.getUID(launcher, userName);

--- a/src/main/resources/org/jenkinsci/plugins/chroot/builders/ChrootBuilder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/chroot/builders/ChrootBuilder/config.jelly
@@ -38,6 +38,9 @@
 <f:entry field="additionalPackages" title="Requirements">
 <f:textbox/>
 </f:entry>
+<f:entry field="bindMounts" title="Bind mounts (pbuilder only)">
+<f:textbox/>
+</f:entry>
 <f:entry field="ignoreExit" title="Ignore exit code">
 <f:checkbox />
 </f:entry>


### PR DESCRIPTION
This is useful for cases where large volumes of data outside the workspace might be wanted inside it - for example, downloading a full set of Android SDK tarballs takes about 16GB, and it's much easier to have a shared directory available for that cache to be shared between jobs.

This isn't supported by Mock - I'd welcome a smarter way to mask the option on Mock builds, but I couldn't figure out the correct Jelly conditional to only show the textbox for Pbuilder-type chroots.